### PR TITLE
Cleaned up &nbsp; in decoded html

### DIFF
--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -70,7 +70,7 @@ module.exports = async function sourceParser(
     return `${pathPrefix}/static/${fileName}`;
   };
 
-  const $ = cheerio.load(content, { xmlMode: true });
+  const $ = cheerio.load(content, { xmlMode: true, decodeEntities: false });
 
   let imageRefs = [];
   let pRefs = [];
@@ -204,7 +204,7 @@ module.exports = async function sourceParser(
     }
 
     $(item).attr('src', swapVal.src);
-    $(item).attr('data-gts-encfluid', swapVal.encoded);
+    $(item).attr('data-gts-encfluid', swapVal.encoded.replace(/"/g, '&quot;'));
     $(item).removeAttr('srcset');
     $(item).removeAttr('sizes');
   });


### PR DESCRIPTION
Due to Cheerio needing the content to be decoded to work its replace magic, I was not able to use the decodeEntities: false flag. I have had to make a slight work around to replace with spaces.

It is a relatively small change, but fixes this issue :)

Cheers,
Rob

