### PR TITLE
add correction if wordPressUrl is a subdirectory

### DIFF
--- a/src/contentParser.js
+++ b/src/contentParser.js
@@ -31,21 +31,11 @@ export default function contentParser(
     return content;
   }
 
-  const subdirectoryCorrection = path => {
+  const subdirectoryCorrection = (path, wordPressUrl) => {
     const wordPressUrlParsed = new URIParser(wordPressUrl);
     // detect if WordPress is installed in subdirectory
-    const subdirectoryRegex = new RegExp(
-      `^https?:\/\/${wordPressUrlParsed.hostname()}(\/.*[^\/])\/?$`,
-      'i'
-    );
-    const match = wordPressUrl.match(subdirectoryRegex);
-    if (!match) {
-      return path;
-    }
-    const subdirectory = match[1];
-    //remove subdirectory from the beginning of the path
-    const regex = new RegExp(`^${subdirectory}`);
-    return path.replace(regex, '');
+    const subdir = wordPressUrlParsed.path();
+    return path.replace(subdir, '/');
   };
 
   const parserOptions = {
@@ -89,7 +79,7 @@ export default function contentParser(
         !elementUrlNoProtocol.includes(uploadsUrlNoProtocol)
       ) {
         let url = urlParsed.path();
-        url = subdirectoryCorrection(url);
+        url = subdirectoryCorrection(url, wordPressUrl);
         return (
           <Styled.a as={Link} to={url} className={className}>
             {domToReact(domNode.children, parserOptions)}

--- a/src/contentParser.js
+++ b/src/contentParser.js
@@ -31,6 +31,23 @@ export default function contentParser(
     return content;
   }
 
+  const subdirectoryCorrection = path => {
+    const wordPressUrlParsed = new URIParser(wordPressUrl);
+    // detect if WordPress is installed in subdirectory
+    const subdirectoryRegex = new RegExp(
+      `^https?:\/\/${wordPressUrlParsed.hostname()}(\/.*[^\/])\/?$`,
+      'i'
+    );
+    const match = wordPressUrl.match(subdirectoryRegex);
+    if (!match) {
+      return path;
+    }
+    const subdirectory = match[1];
+    //remove subdirectory from the beginning of the path
+    const regex = new RegExp(`^${subdirectory}`);
+    return path.replace(regex, '');
+  };
+
   const parserOptions = {
     replace: domNode => {
       let elementUrl =
@@ -72,6 +89,7 @@ export default function contentParser(
         !elementUrlNoProtocol.includes(uploadsUrlNoProtocol)
       ) {
         let url = urlParsed.path();
+        url = subdirectoryCorrection(url);
         return (
           <Styled.a as={Link} to={url} className={className}>
             {domToReact(domNode.children, parserOptions)}


### PR DESCRIPTION
Hi! Huge thanks you for this plugin!
There is a problem if WordPress is installed in a subdirectory (for example https://mydomain.com/subdirectory).
In that case the internal links are not parsed correctly to gatsby Links.
What happens is that https://mydomain.com/subdirectory/page1 becomes /subdirectory/page1 and not /page1

The `subdirectoryCorrection` function should fix it.